### PR TITLE
fix(navigation): reactive sidebar responsiveness; remove window.inner…

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,12 +1,28 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useApp } from '../context/AppContext';
 
 const Navigation = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(typeof window !== 'undefined' ? window.innerWidth >= 1024 : false);
   const location = useLocation();
   const { state } = useApp();
+
+  useEffect(() => {
+    const handleResize = () => {
+      const desktopNow = window.innerWidth >= 1024;
+      setIsDesktop(desktopNow);
+      if (desktopNow) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    // Initialize on mount in case of SSR/hydration differences
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const navigationItems = [
     { path: '/dashboard', label: 'Dashboard', icon: '📊' },
@@ -41,7 +57,7 @@ const Navigation = () => {
 
       {/* Sidebar */}
       <AnimatePresence>
-        {(isMobileMenuOpen || window.innerWidth >= 1024) && (
+        {(isMobileMenuOpen || isDesktop) && (
           <motion.nav
             initial={{ x: -320 }}
             animate={{ x: 0 }}


### PR DESCRIPTION
…Width in render


## Description

- Replace render-time window.innerWidth check with reactive isDesktop state driven by a resize listener.
- Add useEffect to subscribe/unsubscribe to resize events; includes cleanup to avoid leaks.
- Use (isMobileMenuOpen || isDesktop) for sidebar visibility and auto-close mobile menu when switching to desktop.
- Prevents sidebar/content misalignment after viewport changes.

## Semver Changes

- [x] Patch (bug fix, no new features)
- [ ] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

## Issues

> List any issues that this pull request closes.

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

