### PR TITLE
fix(socket): improve connection reliability and surface errors

### DIFF
--- a/server/mock-socket-server.js
+++ b/server/mock-socket-server.js
@@ -12,7 +12,7 @@ app.use(cors());
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: {
-    origin: "http://localhost:3000",
+    origin: ["http://localhost:5173", "http://localhost:3000"],
     methods: ["GET", "POST"]
   }
 });

--- a/src/context/NotificationContext.jsx
+++ b/src/context/NotificationContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useReducer } from 'react';
+import React, { createContext, useContext, useReducer, useCallback } from 'react';
 import { toast } from 'react-toastify';
 
 const NotificationContext = createContext();
@@ -36,7 +36,7 @@ function notificationReducer(state, action) {
 export function NotificationProvider({ children }) {
   const [state, dispatch] = useReducer(notificationReducer, initialState);
 
-  const addNotification = (notification) => {
+  const addNotification = useCallback((notification) => {
     dispatch({ type: 'ADD_NOTIFICATION', payload: notification });
     
     // Show toast based on notification type
@@ -53,15 +53,15 @@ export function NotificationProvider({ children }) {
       default:
         toast.info(notification.message);
     }
-  };
+  }, []);
 
-  const removeNotification = (id) => {
+  const removeNotification = useCallback((id) => {
     dispatch({ type: 'REMOVE_NOTIFICATION', payload: id });
-  };
+  }, []);
 
-  const clearNotifications = () => {
+  const clearNotifications = useCallback(() => {
     dispatch({ type: 'CLEAR_NOTIFICATIONS' });
-  };
+  }, []);
 
   return (
     <NotificationContext.Provider value={{

--- a/src/context/SocketContext.jsx
+++ b/src/context/SocketContext.jsx
@@ -15,9 +15,13 @@ export function SocketProvider({ children }) {
     // Connect to mock server - in production, replace with actual server URL
     const newSocket = io('http://localhost:3001', {
       transports: ['websocket'],
+      reconnection: true,
+      reconnectionAttempts: Infinity,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000,
     });
 
-    newSocket.on('connection', () => {
+    newSocket.on('connect', () => {
       setIsConnected(true);
       addNotification({
         type: 'success',
@@ -31,6 +35,41 @@ export function SocketProvider({ children }) {
       addNotification({
         type: 'error',
         message: 'Disconnected from server',
+        timestamp: new Date(),
+      });
+    });
+
+    newSocket.on('connect_error', (err) => {
+      setIsConnected(false);
+      addNotification({
+        type: 'error',
+        message: `Connection error: ${err.message}`,
+        timestamp: new Date(),
+      });
+    });
+
+    newSocket.on('reconnect_attempt', (attempt) => {
+      addNotification({
+        type: 'info',
+        message: `Reconnecting... (attempt ${attempt})`,
+        timestamp: new Date(),
+      });
+    });
+
+    newSocket.on('reconnect', (attempt) => {
+      setIsConnected(true);
+      addNotification({
+        type: 'success',
+        message: `Reconnected after ${attempt} attempt(s)`,
+        timestamp: new Date(),
+      });
+    });
+
+    newSocket.on('reconnect_failed', () => {
+      setIsConnected(false);
+      addNotification({
+        type: 'error',
+        message: 'Reconnection failed',
         timestamp: new Date(),
       });
     });
@@ -62,6 +101,19 @@ export function SocketProvider({ children }) {
       dispatch({ type: 'UPDATE_SENSOR_DATA', payload: data });
     });
 
+    // Surface server-side notifications and command acknowledgements
+    newSocket.on('notification', (notification) => {
+      addNotification(notification);
+    });
+
+    newSocket.on('command_ack', (ack) => {
+      addNotification({
+        type: ack.success ? 'success' : 'error',
+        message: ack.success ? `Command ${ack.command} succeeded` : `Command ${ack.command} failed: ${ack.error || 'unknown error'}`,
+        timestamp: new Date(),
+      });
+    });
+
     setSocket(newSocket);
 
     return () => newSocket.close();
@@ -84,6 +136,7 @@ export function SocketProvider({ children }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useSocket() {
   const context = useContext(SocketContext);
   if (!context) {


### PR DESCRIPTION
## Description

- Improve Socket.IO reliability and visibility of errors in development.
- Use connect event (instead of connection) in client.
- Add reconnection strategy and toasts for connect_error, reconnect_attempt, reconnect, reconnect_failed.
- Subscribe to server notification and command_ack events.
- Memoize notification actions (addNotification, removeNotification, clearNotifications) to stabilize effect dependencies.
- Allow Vite dev origin (http://localhost:5173) in mock server CORS.

Affected files:

- src/context/SocketContext.jsx
- src/context/NotificationContext.jsx
- server/mock-socket-server.js

## Semver Changes

- [x] Patch (bug fix, no new features)
- [ ] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

## Issues

> List any issues that this pull request closes.

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

